### PR TITLE
fix: Fix Error Handling for the POST posts Endpoint

### DIFF
--- a/packages/hackmcx-api/src/controllers/posts.controller.js
+++ b/packages/hackmcx-api/src/controllers/posts.controller.js
@@ -23,30 +23,25 @@ export async function getPostById(req, res){
 }
 
 export async function postPost(req, res){
-    const imageURL = req.body.imageURL;
-    const regex = /(https?:\/\/.*\.(?:png|jpg|gif|svg))/i;
-    const isPicture = imageURL && imageURL.match(regex)[0] === imageURL;
-    const emptyTitle = req.body.title && /^\s*$/.test(req.body.title);
+    const notPicture = !req.body.imageUrl || !/(https?:\/\/.*\.(?:png|jpg|gif|svg))/i.test(req.body.imageUrl);
+    const emptyTitle = !req.body.title || /^\s*$/.test(req.body.title);
 
-    if(!isPicture){
+    if(notPicture){
         res.statusCode = 400;
-        res.send({
-            error: "Invalid image URL: Image url is either missing or invalid."
-        })
+        res.send({error: "Invalid image URL: Image url is either missing or invalid."});
+
+        return
     }
 
     if (emptyTitle){
         res.statusCode = 400;
-        res.send({
-            error: "Title cannot be missing or blank."
-        })
+        res.send({error: "Title cannot be missing or blank."});
+
+        return
     }
 
-    dbClient
-        .insert(req.body).into('posts')
-        .then(result => {
-            res.statusCode = 201
-            // TODO: Set location header... res.header('Location', req.)
-            res.send(result)
-        })
+    let id = (await dbClient.table('posts').insert({imageUrl: req.body.imageUrl, title: req.body.title}))[0];
+    res.statusCode = 201;
+    res.header('Location',`${req.baseUrl}/${id}` );
+    res.send();
 }


### PR DESCRIPTION
Update the POST posts endpoint to properly handle errors when title or
imageUrl are not specified in the request body. Also add the location
header to the response so the client knows where to get the post that
was created.

#29