### PR TITLE
fix: remove duplicate posts with matching average

### DIFF
--- a/packages/hackmcx-api/src/controllers/posts.controller.js
+++ b/packages/hackmcx-api/src/controllers/posts.controller.js
@@ -9,6 +9,7 @@ export async function getPosts(req, res){
           this.on('posts.id', '=', 'post_id')
           this.andOn('average_rating', '=', dbClient.raw('(select max(??) from ?? where ??=??)', ['average_rating', 'captions', 'post_id', 'c.post_id']))
         })
+        .groupBy('posts.id')
         .then(results => {finalResults = results})
 
     finalResults.forEach(function (post, index) {


### PR DESCRIPTION
Duplicate posts are listed if there are captions
with same max average rating

#79